### PR TITLE
Revert to a non-AGPL version of QuickShop-Hikari API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,10 +47,10 @@ repositories {
 
 dependencies {
     compileOnly("org.purpurmc.purpur:purpur-api:1.19.4-R0.1-SNAPSHOT")
-    compileOnly("com.ghostchu:quickshop-api:6.2.0.6")
+    compileOnly("com.ghostchu:quickshop-api:5.2.0.7")
     compileOnly(files("libs/AreaShop-2.9.1.jar"))
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.8")
-    implementation("com.ghostchu.quickshop.compatibility:common:6.2.0.6")
+    implementation("com.ghostchu.quickshop.compatibility:common:5.2.0.7")
 }
 
 tasks.withType<AbstractArchiveTask>().configureEach { // Ensure reproducible builds.


### PR DESCRIPTION
QuickShop-Hikari switched to AGPL. This API version matches the one on TrueOG's GPLv3 fork here: https://github.com/true-og/QuickShop-OG